### PR TITLE
Support special characters within quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ gox -arch="386 amd64" -os="darwin linux windows"
 ```
 export foo="bar"
 export bar="[foo,bar]"
-export foobar="{foo:bar,bar:foo}"
+export foobar="{foo:bar,bar:foo,url:\"http://foo.bar\"}"
 export foobaz="{foo:[bar,baz]}" 
 export baz="1.0-123"
 export number="59614658972"

--- a/test/test.txt
+++ b/test/test.txt
@@ -40,7 +40,7 @@ access element in list:
 _bar
 
 map:
-_map[foo:bar bar:foo]
+_map[bar:foo foo:bar url:http://foo.bar]
 
 empty map:
 _map[]
@@ -48,6 +48,7 @@ _map[]
 iterate over map with key and value:
 _bar:foo
 _foo:bar
+_url:http://foo.bar
 
 
 access element in map:

--- a/tpl.go
+++ b/tpl.go
@@ -31,12 +31,14 @@ func inputToObject(inputStr string, debug *bool) (result interface{}, err error)
 		lastWasSpecial, _ := regexp.MatchString("[{}\\[\\]:,]", lastChar)
 		isClosingBrace, _ := regexp.MatchString("[}\\]]", currentChar)
 		lastWasClosingBrace, _ := regexp.MatchString("[^}\\]]", lastChar)
+		isQuote, _ := regexp.MatchString("[\"]", currentChar)
+		lastWasQuote, _ := regexp.MatchString("[\"]", lastChar)
 
-		if currentChar == "\"" {
+		if isQuote {
 			insideQuotes = !insideQuotes
 		}
 
-		if !insideQuotes && lastChar != "\"" {
+		if !insideQuotes && !lastWasQuote {
 			if position > 0 && isOpeningBrace && !lastWasSpecial {
 				jsonStr += "\""
 			}

--- a/tpl.go
+++ b/tpl.go
@@ -16,6 +16,7 @@ import (
 func inputToObject(inputStr string, debug *bool) (result interface{}, err error) {
 	jsonStr := ""
 	lastChar := ""
+	insideQuotes := false
 
 	if *debug {
 		fmt.Fprintf(os.Stderr, "input is: %v\n", inputStr)
@@ -31,20 +32,26 @@ func inputToObject(inputStr string, debug *bool) (result interface{}, err error)
 		isClosingBrace, _ := regexp.MatchString("[}\\]]", currentChar)
 		lastWasClosingBrace, _ := regexp.MatchString("[^}\\]]", lastChar)
 
-		if position > 0 && isOpeningBrace && !lastWasSpecial {
-			jsonStr += "\""
+		if currentChar == "\"" {
+			insideQuotes = !insideQuotes
 		}
 
-		if isNotSpecial && lastWasSpecial {
-			jsonStr += "\""
-		}
+		if !insideQuotes && lastChar != "\"" {
+			if position > 0 && isOpeningBrace && !lastWasSpecial {
+				jsonStr += "\""
+			}
 
-		if isColonOrComma && lastWasClosingBrace {
-			jsonStr += "\""
-		}
+			if isNotSpecial && lastWasSpecial {
+				jsonStr += "\""
+			}
 
-		if isClosingBrace && !lastWasSpecial {
-			jsonStr += "\""
+			if isColonOrComma && lastWasClosingBrace {
+				jsonStr += "\""
+			}
+
+			if isClosingBrace && !lastWasSpecial {
+				jsonStr += "\""
+			}
 		}
 
 		jsonStr += currentChar


### PR DESCRIPTION
I was trying to setup a env var like:

```
BACKENDS: "{my_app: http://my_app}"
```
but current parsing was splitting it by `:`. I have added support to use quotes to enclose special chars